### PR TITLE
refactor(middleware): simplify auth page check and update redirect URL

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,14 +4,20 @@ import type { NextRequest } from 'next/server';
 export function middleware(request: NextRequest) {
   const authCookie = request.cookies.get('auth-user');
   const isUserAuthenticated = authCookie?.value ? JSON.parse(authCookie.value) : null;
-  const isAuthPage = request.nextUrl.pathname === '/sign-in' || request.nextUrl.pathname === '/sign-up' || request.nextUrl.pathname === '/sales';
+
+  const authPages = [
+    // '/sign-in', 
+    // '/sign-up', 
+    '/sales']; // Lista de páginas de autenticação
+  // Verifica se a URL atual é uma página de autenticação ou não
+  const isAuthPage = authPages.includes(request.nextUrl.pathname);
 
   if (isUserAuthenticated) {
     if (isAuthPage) {
       return NextResponse.redirect(new URL('/dashboard', request.url));
     }
   } else if (!isAuthPage) {
-    return NextResponse.redirect(new URL('/sign-in', request.url));
+    return NextResponse.redirect(new URL('/sales', request.url));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
Replace hardcoded pathname checks with an array of auth pages for better maintainability. Update the redirect URL from '/sign-in' to '/sales' for consistency with the auth page list.