### PR TITLE
fix(replicate.service): prepend 'https://' to forwarded host URL

### DIFF
--- a/src/services/replicate.service.ts
+++ b/src/services/replicate.service.ts
@@ -24,7 +24,7 @@ export const generateOutline = async ({
     const getUrl =
       process.env.NODE_ENV === 'development'
         ? process.env.NEXT_PUBLIC_SITE_URL
-        : headersList.get('x-forwarded-host');
+        : `https://${headersList.get('x-forwarded-host')}`;
 
     const response = await fetch(`${getUrl}/api/outline`, {
       method: 'POST',


### PR DESCRIPTION
Ensure the URL is properly formatted by adding the 'https://' protocol when constructing the URL from the 'x-forwarded-host' header. This prevents potential issues with malformed URLs in production environments.