### PR TITLE
refactor(api): update replicate prediction model configuration

### DIFF
--- a/src/app/api/image/route.ts
+++ b/src/app/api/image/route.ts
@@ -96,7 +96,7 @@ export async function POST(request: Request) {
     };
 
     const prediction = await replicate.predictions.create({
-      version: '6136f7a0938f52e109178509185b6d3a057c121d2e6ab3db327156986c12ea8d',
+      model: "aillustra-dev/aillustra-color:6136f7a0938f52e109178509185b6d3a057c121d2e6ab3db327156986c12ea8d",
       input
     });
 


### PR DESCRIPTION
The `version` field in the replicate prediction configuration was replaced with the `model` field to align with the updated API requirements. This ensures compatibility with the latest replicate API changes.